### PR TITLE
fix: update npm package json default fields

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -151,4 +151,7 @@ exports.keepStandardFields = [
   "module",
   "type", // module type
   "types", // typescript types
+
+  // ESM
+  "exports",
 ];

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -153,5 +153,6 @@ exports.keepStandardFields = [
   "types", // typescript types
 
   // ESM
-  "exports",
+  "exports", // subpath exports entry point
+  "imports", // subpath imports entry point
 ];


### PR DESCRIPTION
This PR adds the "exports" and "imports" fields to the list of common npm package fields.

Example:
```js
{
  ...
  "exports": { .. },
  "imports": { .. },
}
```

Before this change, the package would need to be configured with `publishUtil: { keep: [ "exports", "imports" ] }`, even though these are standard in Node after v14.